### PR TITLE
Making some changes to HDR project generation

### DIFF
--- a/auto_pano_and_hdr.sh
+++ b/auto_pano_and_hdr.sh
@@ -2,6 +2,8 @@
 
 #set -e
 
-find ./ -name 'hdr*' -print0 | xargs -0 -P 4 -I% ~/Pictures/scripts/autohdr.sh %
-find ./ -name 'pano*' -print0 | xargs -0 -P 1 -I% ~/Pictures/scripts/autoPano.sh %
+SCRIPTS_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
+find ./ -name 'hdr*' -print0 | xargs -0 -P 4 -I% $SCRIPTS_DIR/autohdr.sh %
+find ./ -name 'pano*' -print0 | xargs -0 -P 1 -I% $SCRIPTS_DIR/autoPano.sh %
 

--- a/autohdr.sh
+++ b/autohdr.sh
@@ -19,13 +19,14 @@ echo "creating '$OUTPUT_FILE'..."
 NUM_IMAGES=$(ls $DIR/*.JPG -l | wc -l)
 
 
-pto_gen $DIR/*.JPG -s $NUM_IMAGES -o $OUTPUT_FILE #-s to set stacks to avoid "enblend: excessive overlap detected" in the event that it can't automaticly detect stacks. But not -l so we don't link positions
+pto_gen $DIR/*.JPG -s $NUM_IMAGES -o $OUTPUT_FILE
 cpfind -o $OUTPUT_FILE $OUTPUT_FILE 
 cpclean -o $OUTPUT_FILE $OUTPUT_FILE 
 autooptimiser -p -o $OUTPUT_FILE $OUTPUT_FILE 
 
 
 # -p 0 => rectaliniar projection
-pano_modify -o $OUTPUT_FILE -p 0 --ldr-file=JPG --output-type=BF $OUTPUT_FILE
+# --output-type=FB => fuse then blend, it shouldn't really matter which one we do first for an HDR but my expereince is FB helps avoid the "enblend: excessive overlap detected" error
+pano_modify -o $OUTPUT_FILE -p 0 --ldr-file=JPG --output-type=FB $OUTPUT_FILE
 pano_modify -o $OUTPUT_FILE --fov=AUTO --canvas=AUTO --crop=AUTO $OUTPUT_FILE
 

--- a/autohdr.sh
+++ b/autohdr.sh
@@ -19,7 +19,7 @@ echo "creating '$OUTPUT_FILE'..."
 NUM_IMAGES=$(ls $DIR/*.JPG -l | wc -l)
 
 
-pto_gen $DIR/*.JPG -o -s $NUM_IMAGES $OUTPUT_FILE #-s to set stacks to avoid "enblend: excessive overlap detected" in the event that it can't automaticly detect stacks. But not -l so we don't link positions
+pto_gen $DIR/*.JPG -s $NUM_IMAGES -o $OUTPUT_FILE #-s to set stacks to avoid "enblend: excessive overlap detected" in the event that it can't automaticly detect stacks. But not -l so we don't link positions
 cpfind -o $OUTPUT_FILE $OUTPUT_FILE 
 cpclean -o $OUTPUT_FILE $OUTPUT_FILE 
 autooptimiser -p -o $OUTPUT_FILE $OUTPUT_FILE 

--- a/autohdr.sh
+++ b/autohdr.sh
@@ -16,10 +16,14 @@ echo "Processing directory $DIR"
 OUTPUT_FILE=$(ls $DIR/*.JPG | head -n 1 | sed -e 's/\.JPG$/_hdr.pto/')
 echo "creating '$OUTPUT_FILE'..."
 
-pto_gen $DIR/*.JPG -o $OUTPUT_FILE
+NUM_IMAGES=$(ls $DIR/*.JPG -l | wc -l)
+
+
+pto_gen $DIR/*.JPG -o -s $NUM_IMAGES $OUTPUT_FILE #-s to set stacks to avoid "enblend: excessive overlap detected" in the event that it can't automaticly detect stacks. But not -l so we don't link positions
 cpfind -o $OUTPUT_FILE $OUTPUT_FILE 
 cpclean -o $OUTPUT_FILE $OUTPUT_FILE 
 autooptimiser -p -o $OUTPUT_FILE $OUTPUT_FILE 
+
 
 # -p 0 => rectaliniar projection
 pano_modify -o $OUTPUT_FILE -p 0 --ldr-file=JPG --output-type=BF $OUTPUT_FILE


### PR DESCRIPTION
The bigger changes in here is I am setting the stack size and switching --output-type=BF to --output-type=FB. This is because I keep getting errors from enblend about excessive overlap. If you know of another way of preventing these errors I am all ears.