### PR TITLE
Let auto_pano_and_hdr.sh accept director as input. and make directory names safe to white space

### DIFF
--- a/auto_hdr.sh
+++ b/auto_hdr.sh
@@ -14,39 +14,39 @@ done
 shift $((OPTIND-1))
 [ "$1" = "--" ] && shift
 
-DIR=$1
+DIR="$1"
 
-if [ x$DIR == x"" ]; then
+if [ x"$DIR" == x"" ]; then
     echo >&2 "Usage: auto_hdr.sh [-s] [-h] dir"
     echo >&2 "    No directory provided"
     exit 2
 fi
-if [ ! -d $DIR ]; then
+if [ ! -d "$DIR" ]; then
     echo "Directory $DIR does not exist."
     exit 3
 fi
 echo "Processing directory $DIR"
 
 # generate the project name from the first input file name
-BASE_NAME=$(ls $DIR/*.JPG | head -n 1 | sed -e 's/\.JPG$/_hdr/')
-OUTPUT_FILE=$BASE_NAME'.pto'
+BASE_NAME=$(ls "$DIR"/*.JPG | head -n 1 | sed -e 's/\.JPG$/_hdr/')
+OUTPUT_FILE="$BASE_NAME"'.pto'
 echo "creating '$OUTPUT_FILE'..."
 
 # Pass the stack size to pto_gen if needed
 if [ x$STACK_SIZE == x"" ]; then
-    pto_gen $DIR/*.JPG -o $OUTPUT_FILE
+    pto_gen "$DIR"/*.JPG -o "$OUTPUT_FILE"
 else
-    pto_gen $DIR/*.JPG -s $STACK_SIZE -o $OUTPUT_FILE
+    pto_gen "$DIR"/*.JPG -s $STACK_SIZE -o "$OUTPUT_FILE"
 fi
 
-cpfind -o $OUTPUT_FILE $OUTPUT_FILE 
-cpclean -o $OUTPUT_FILE $OUTPUT_FILE 
-autooptimiser -p -o $OUTPUT_FILE $OUTPUT_FILE 
+cpfind -o "$OUTPUT_FILE" "$OUTPUT_FILE" 
+cpclean -o "$OUTPUT_FILE" "$OUTPUT_FILE" 
+autooptimiser -p -o "$OUTPUT_FILE" "$OUTPUT_FILE" 
 
 # -p 0 => rectaliniar projection
-pano_modify -o $OUTPUT_FILE -p 0 --ldr-file=JPG --output-type=BF $OUTPUT_FILE
-pano_modify -o $OUTPUT_FILE --fov=AUTO --canvas=AUTO --crop=AUTO $OUTPUT_FILE
+pano_modify -o "$OUTPUT_FILE" -p 0 --ldr-file=JPG --output-type=BF "$OUTPUT_FILE"
+pano_modify -o "$OUTPUT_FILE" --fov=AUTO --canvas=AUTO --crop=AUTO "$OUTPUT_FILE"
 
 # add it to the batch processer
-nohup PTBatcherGUI $OUTPUT_FILE $BASE_NAME >/dev/null 2>&1 &
+nohup PTBatcherGUI "$OUTPUT_FILE" "$BASE_NAME" >/dev/null 2>&1 &
 

--- a/auto_pano.sh
+++ b/auto_pano.sh
@@ -14,40 +14,40 @@ done
 shift $((OPTIND-1))
 [ "$1" = "--" ] && shift
 
-DIR=$1
+DIR="$1"
 
-if [ x$DIR == x"" ]; then
+if [ x"$DIR" == x"" ]; then
     echo >&2 "Usage: auto_pano.sh [-s] [-h] dir"
     echo >&2 "    No directory provided"
     exit 2
 fi
-if [ ! -d $DIR ]; then
+if [ ! -d "$DIR" ]; then
     echo "Directory $DIR does not exist."
     exit 3
 fi
 echo "Processing directory $DIR"
 
 # generate the project name from the first input file name
-BASE_NAME=$(ls $DIR/*.JPG | head -n 1 | sed -e 's/\.JPG$/_pano/')
-OUTPUT_FILE=$BASE_NAME'.pto'
+BASE_NAME=$(ls "$DIR"/*.JPG | head -n 1 | sed -e 's/\.JPG$/_pano/')
+OUTPUT_FILE="$BASE_NAME"'.pto'
 echo "creating '$OUTPUT_FILE'..."
 
 # Pass the stack size to pto_gen if needed
 if [ x$STACK_SIZE == x"" ]; then
-    pto_gen $DIR/*.JPG -o $OUTPUT_FILE
+    pto_gen "$DIR/"*.JPG -o "$OUTPUT_FILE"
 else
-    pto_gen $DIR/*.JPG -s $STACK_SIZE -o $OUTPUT_FILE
+    pto_gen "$DIR/"*.JPG -s $STACK_SIZE -o "$OUTPUT_FILE"
 fi
 
-cpfind -o $OUTPUT_FILE $OUTPUT_FILE
-#cpclean -o $OUTPUT_FILE $OUTPUT_FILE
-autooptimiser -a -l -s -o $OUTPUT_FILE $OUTPUT_FILE
+cpfind -o "$OUTPUT_FILE" "$OUTPUT_FILE"
+#cpclean -o "$OUTPUT_FILE" "$OUTPUT_FILE"
+autooptimiser -a -l -s -o "$OUTPUT_FILE" "$OUTPUT_FILE"
 
 # -p 0 => rectaliniar projection
-#pano_modify -o $OUTPUT_FILE -p 0 --ldr-file=JPG --output-type=BF $OUTPUT_FILE
-pano_modify -o $OUTPUT_FILE --output-type=BF $OUTPUT_FILE
-pano_modify -o $OUTPUT_FILE --center --straighten --canvas=AUTO --crop=AUTO $OUTPUT_FILE
+#pano_modify -o "$OUTPUT_FILE" -p 0 --ldr-file=JPG --output-type=BF "$OUTPUT_FILE"
+pano_modify -o "$OUTPUT_FILE" --output-type=BF "$OUTPUT_FILE"
+pano_modify -o "$OUTPUT_FILE" --center --straighten --canvas=AUTO --crop=AUTO "$OUTPUT_FILE"
 
 # add it to the batch processer
-nohup PTBatcherGUI $OUTPUT_FILE $BASE_NAME >/dev/null 2>&1 &
+nohup PTBatcherGUI "$OUTPUT_FILE" "$BASE_NAME" >/dev/null 2>&1 &
 

--- a/auto_pano_and_hdr.sh
+++ b/auto_pano_and_hdr.sh
@@ -11,17 +11,32 @@ do
             exit 1;;
     esac
 done
+shift $((OPTIND-1))
+[ "$1" = "--" ] && shift
+
+PARENT_DIR="$1"
+
+if [ x"$PARENT_DIR" == x"" ]; then
+    echo >&2 "Usage: auto_pano_and_hdr.sh [-P] [-h] dir"
+    echo >&2 "    No directory provided"
+    exit 2
+fi
+if [ ! -d $DIR ]; then
+    echo "Directory $PARENT_DIR does not exist."
+    exit 3
+fi
 
 SCRIPTS_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
 if [ x$NUM_PROCS == x"" ]; then
-    find ./ -name 'hdr*' -print0 | xargs -0 -P 4 -I% $SCRIPTS_DIR/auto_hdr.sh %
-    find ./ -name 'pano*' -print0 | xargs -0 -P 1 -I% $SCRIPTS_DIR/auto_pano.sh %
+    find "$PARENT_DIR" -name 'hdr*' -print0 | xargs -0 -P 4 -I% "$SCRIPTS_DIR"/auto_hdr.sh %
+    find "$PARENT_DIR" -name 'pano*' -print0 | xargs -0 -P 1 -I% "$SCRIPTS_DIR"/auto_pano.sh %
 else
-    find ./ -name 'hdr*' -print0 | xargs -0 -P $NUM_PROCS -I% $SCRIPTS_DIR/auto_hdr.sh %
-    find ./ -name 'pano*' -print0 | xargs -0 -P $NUM_PROCS -I% $SCRIPTS_DIR/auto_pano.sh %
+    find "$PARENT_DIR" -name 'hdr*' -print0 | xargs -0 -P $NUM_PROCS -I% "$SCRIPTS_DIR"/auto_hdr.sh %
+    find "$PARENT_DIR" -name 'pano*' -print0 | xargs -0 -P $NUM_PROCS -I% "$SCRIPTS_DIR"/auto_pano.sh %
 fi
 
 #Start stiching
+echo "Starting stiching in the BatchProcesser"
 nohup PTBatcherGUI -b >/dev/null 2>&1 &
 


### PR DESCRIPTION
This change does two things:

1. In the help text for the "auto_pano_and_hdr.sh" we say that we accept the directory as an input argument, but we don'. Right now this script only works for directories in the current directory. This change forces auto_pano_and_hdr.sh to use input argument to accept the directory it works on. There is still some question in my mind as far as what we should do if you don't provide the directory as an input, right now I have it throw an error to be consistant with the other "auto_XXX" scripts but if you want we could have it just use the current directory since that is the old behavior.

2. Previously these scripts wouldn't work if there was whitespace in the directory names. I fixed this by putting lots of double quotes whereever we are using a variable that has a directory name. See:
http://www.linuxjournal.com/article/10954
https://unix.stackexchange.com/questions/67757/wildcards-inside-quotes